### PR TITLE
Bugfix: href for favicon is quoted with wrong character.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -8,7 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
     <link rel="stylesheet" href="./css/style.css">
-    <link rel=”icon” href=“./media/image/favicon.ico”>
+    <link rel=”icon” href="./media/image/favicon.ico">
   </head>
 
   <body>


### PR DESCRIPTION
faviconのhrefのダブルクォーテーションが間違っていたので修正。